### PR TITLE
Fixed faculty box responsiveness

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -706,15 +706,15 @@ body {
   backface-visibility: hidden; }
   @media only screen and (max-width: 75em) {
     .faculty-box {
-      height: 30rem;
+      min-height: 30rem;
       padding: 1.5rem; } }
   @media only screen and (max-width: 56.25em) {
     .faculty-box {
-      height: 30rem;
+      min-height: 30rem;
       padding: 2rem; } }
   @media only screen and (max-width: 37.5em) {
     .faculty-box {
-      height: 15rem;
+      min-height: 15rem;
       padding: 2rem; } }
   .faculty-box__profile-pic {
     width: 12rem;

--- a/sass/components/_faculty-box.scss
+++ b/sass/components/_faculty-box.scss
@@ -10,17 +10,17 @@
     backface-visibility: hidden;
 
     @include respond(tab-land){
-        height: 30rem;
+        min-height: 30rem;
         padding: 1.5rem;
     }
 
     @include respond(tab-port) {
-        height: 30rem;
+        min-height: 30rem;
         padding: 2rem;
     }
 
      @include respond(phone) {
-         height: 15rem;
+         min-height: 15rem;
          padding: 2rem;
      }
 
@@ -170,6 +170,3 @@
 
 
 }
-
-
-


### PR DESCRIPTION
Faculty boxes will cut off at the bottom at smaller screen widths. Changed height properties to min-height to fix this issue.